### PR TITLE
Move to a new version of setup-uv

### DIFF
--- a/.github/workflows/deploys.yml
+++ b/.github/workflows/deploys.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.3.2
 
       - name: Build docs
         run: uv run mkdocs build


### PR DESCRIPTION
Astral no longer publishes `v8` tags, so it's up to us to pick a version if we don't want to run on the latest all the time