### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/deploys.yml
+++ b/.github/workflows/deploys.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8
 
       - name: Build docs
         run: uv run mkdocs build


### PR DESCRIPTION
Bumps outdated GitHub Actions in the docs deploy workflow.

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | v4 | v7 |
| `astral-sh/setup-uv` | v5 | v8 |

`peaceiris/actions-gh-pages` was already current (v4).

Both are major-version bumps but drop-in compatible for this build/deploy flow.